### PR TITLE
[patch] Import annotations for 3.9 compatibility with type hint sugar

### DIFF
--- a/pyiron_snippets/resources.py
+++ b/pyiron_snippets/resources.py
@@ -2,6 +2,8 @@
 Classes to find data files and executables in global paths.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Iterable
 import os


### PR DESCRIPTION
Closes #23 

(At least it should. [python not-3.12 tests are not actually being run](https://github.com/pyiron/actions/issues/123) so we'll get final confirmation in the PR that updates the CI version to fix this. For now I will close the issue on merge in faith.)