### PR TITLE
[patch] Allow `_FactoryMade` to explicitly define where its reduce should import from

### DIFF
--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -278,8 +278,8 @@ class _FactoryMade(ABC):
                 self.__getstate__(),
             )
         elif (
-            self._reduce_imports_as is not None and
-            "<locals>" not in self._reduce_imports_as[1]
+            self._reduce_imports_as is not None
+            and "<locals>" not in self._reduce_imports_as[1]
         ):
             return (
                 _instantiate_from_decorated,

--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -249,7 +249,7 @@ class _FactoryMade(ABC):
     # DEPRECATED: Use _reduce_imports_as instead
     _class_returns_from_decorated_function: ClassVar[callable | None] = None
 
-    _reduce_imports_as: ClassVar[tuple[str, str] | None] = None
+    _reduce_imports_as: ClassVar[tuple[str, str] | None] = None  # Module and qualname
 
     def __init_subclass__(cls, /, class_factory, class_factory_args, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -237,13 +237,15 @@ class _FactoryMade(ABC):
     """
     A mix-in to make class-factory-produced classes pickleable.
 
-    If the factory is used as a decorator for another function, it will conflict with
-    this function (i.e. the owned function will be the true function, and will mismatch
-    with imports from that location, which will return the post-decorator factory made
-    class). This can be resolved by setting the :attr:`_reduce_imports_as` attribute
-    to a tuple of the (module, qualname) obtained from the decorated definition (or,
-    -- DEPRECATED -- set :attr:`_class_returns_from_decorated_function` attribute to be
-    the decorated function in the decorator definition.)
+    If the factory is used as a decorator for another function (or class), it will
+    conflict with this function (i.e. the owned function will be the true function,
+    and will mismatch with imports from that location, which will return the
+    post-decorator factory made class). This can be resolved by setting the
+    :attr:`_reduce_imports_as` attribute to a tuple of the (module, qualname) obtained
+    from the decorated definition in order to manually specify where it should be
+    re-imported from. (DEPRECATED alternative: set
+    :attr:`_class_returns_from_decorated_function` attribute to be the decorated
+    function in the decorator definition.)
     """
 
     # DEPRECATED: Use _reduce_imports_as instead

--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -275,7 +275,10 @@ class _FactoryMade(ABC):
                 ),
                 self.__getstate__(),
             )
-        elif self._reduce_imports_as is not None:
+        elif (
+            self._reduce_imports_as is not None and
+            "<locals>" not in self._reduce_imports_as[1]
+        ):
             return (
                 _instantiate_from_decorated,
                 (

--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -240,12 +240,16 @@ class _FactoryMade(ABC):
     If the factory is used as a decorator for another function, it will conflict with
     this function (i.e. the owned function will be the true function, and will mismatch
     with imports from that location, which will return the post-decorator factory made
-    class). This can be resolved by setting the
-    :attr:`_class_returns_from_decorated_function` attribute to be the decorated
-    function in the decorator definition.
+    class). This can be resolved by setting the :attr:`_reduce_imports_as` attribute
+    to a tuple of the (module, qualname) obtained from the decorated definition (or,
+    -- DEPRECATED -- set :attr:`_class_returns_from_decorated_function` attribute to be
+    the decorated function in the decorator definition.)
     """
 
+    # DEPRECATED: Use _reduce_imports_as instead
     _class_returns_from_decorated_function: ClassVar[callable | None] = None
+
+    _reduce_imports_as: ClassVar[tuple[str, str] | None] = None
 
     def __init_subclass__(cls, /, class_factory, class_factory_args, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -267,6 +271,16 @@ class _FactoryMade(ABC):
                 (
                     self._class_returns_from_decorated_function.__module__,
                     self._class_returns_from_decorated_function.__qualname__,
+                    self.__getnewargs_ex__(),
+                ),
+                self.__getstate__(),
+            )
+        elif self._reduce_imports_as is not None:
+            return (
+                _instantiate_from_decorated,
+                (
+                    self._reduce_imports_as[0],
+                    self._reduce_imports_as[1],
                     self.__getnewargs_ex__(),
                 ),
                 self.__getstate__(),


### PR DESCRIPTION
When a `@classfactory` is used inside a decorator, i.e. to create a new class directly from a decorated function or class definition, the new `_FactoryMade` class automatically conflicts with the namespace of its underlying source material. Previously, you could store the underlying function with `_class_returns_from_decorated_function` to avoid this conflict. This PR deprecates (but leaves available) that interface, while providing a new `_reduce_imports_as: tuple[str, str]` allowing you to explicitly specify where the `_FactoryMade` class should be (re)imported from in `__reduce__`. IMO this is a bit clearer, and is necessary flexibility for https://github.com/pyiron/pyiron_workflow/pull/410 which is closing https://github.com/pyiron/pyiron_workflow/issues/319. 
