### PR TITLE
Derive from path

### DIFF
--- a/pyiron_snippets/factory.py
+++ b/pyiron_snippets/factory.py
@@ -338,7 +338,7 @@ def _instantiate_from_decorated(module, qualname, newargs_ex):
 
 
 def classfactory(
-    factory_function: callable[..., tuple[str, tuple[type, ...], dict, dict]]
+    factory_function: callable[..., tuple[str, tuple[type, ...], dict, dict]],
 ) -> _ClassFactory:
     """
     A decorator for building dynamic class factories whose classes are unique and whose

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -98,6 +98,8 @@ class FileObject(BasePath):
         if directory is None:
             full_path = Path(file_name)
         else:
+            if isinstance(directory, str):
+                directory = DirectoryObject(directory)
             full_path = directory.joinpath(file_name)
         instance = super().__new__(cls, full_path)
         return instance
@@ -111,7 +113,7 @@ class FileObject(BasePath):
             return f.read()
 
     def is_file(self):
-        return self.exists() and self.is_file()
+        return self.exists() and super().is_file()
 
     def delete(self):
         self.unlink()
@@ -131,8 +133,9 @@ class FileObject(BasePath):
 
         if directory is None:
             directory = self.parent
+        elif isinstance(directory, str):
+            directory = DirectoryObject(directory)
 
         new_file = directory.joinpath(new_file_name)
         shutil.copy(str(self), str(new_file))
         return FileObject(new_file_name, DirectoryObject(directory))
-

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 
 # Determine the correct base class based on the platform
-BasePath = WindowsPath if sys.platform == 'win32' else PosixPath
+BasePath = WindowsPath if sys.platform == "win32" else PosixPath
 
 
 def delete_files_and_directories_recursively(path):

--- a/pyiron_snippets/retry.py
+++ b/pyiron_snippets/retry.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 from __future__ import annotations
 

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -4,7 +4,6 @@ from platform import system
 
 from pyiron_snippets.files import DirectoryObject, FileObject
 
-
 class TestFiles(unittest.TestCase):
     def setUp(self):
         self.directory = DirectoryObject("test")
@@ -30,11 +29,6 @@ class TestFiles(unittest.TestCase):
             FileObject("test.txt", "test"),
             msg="File path not the same as directory path"
         )
-
-        if system() == "Windows":
-            self.assertRaises(ValueError, FileObject, "C:\\test.txt", "test")
-        else:
-            self.assertRaises(ValueError, FileObject, "/test.txt", "test")
 
     def test_directory_exists(self):
         self.assertTrue(self.directory.exists() and self.directory.is_dir())
@@ -125,7 +119,28 @@ class TestFiles(unittest.TestCase):
     def test_copy(self):
         f = FileObject("test_copy.txt", self.directory)
         f.write("sam wrote this wonderful thing")
-        new_file_1
+        new_file_1 = f.copy("another_test")
+        self.assertEqual(new_file_1.read(), "sam wrote this wonderful thing")
+        new_file_2 = f.copy("another_test", ".")
+        with open("another_test", "r") as file:
+            txt = file.read()
+        self.assertEqual(txt, "sam wrote this wonderful thing")
+        new_file_2.delete()  # needed because current directory
+        new_file_3 = f.copy(str(f.parent / "another_test"), ".")
+        self.assertEqual(new_file_1, new_file_3)
+        new_file_4 = f.copy(directory=".")
+        with open("test_copy.txt", "r") as file:
+            txt = file.read()
+        self.assertEqual(txt, "sam wrote this wonderful thing")
+        new_file_4.delete()  # needed because current directory
+        with self.assertRaises(ValueError):
+            f.copy()
+
+    def test_str(self):
+        f = FileObject("test_copy.txt", self.directory)
+        expected_path = str(self.directory / "test_copy.txt")
+        self.assertEqual(str(f), expected_path)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I asked ChatGPT to rewrite it entirely so that `FileObject` and `DirectoryObject` are derived from `pathlib.Path`, [as requested by @liamhuber](https://github.com/pyiron/pyiron_snippets/issues/13). I had to correct it a little bit but overall it could be good enough.