### PR TITLE
Reorganize `DirectoryObject`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -119,13 +119,7 @@ Shortcuts for filesystem manipulation
 >>>
 >>> d = DirectoryObject("some_dir")
 >>> d.write(file_name="my_filename.txt", content="Some content")
->>> f = FileObject("my_filename.txt", directory=d)
->>> f.is_file()
-True
->>> f2 = f.copy("new_filename.txt", directory=d.create_subdirectory("sub"))
->>> f2.read()
-'Some content'
->>> d.file_exists("sub/new_filename.txt")
+>>> d.file_exists("my_filename.txt")
 True
 >>> d.delete()
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -115,7 +115,7 @@ Make dynamic classes that are still pickle-able
 Shortcuts for filesystem manipulation
 
 ```python
->>> from pyiron_snippets.files import DirectoryObject, FileObject
+>>> from pyiron_snippets.files import DirectoryObject
 >>>
 >>> d = DirectoryObject("some_dir")
 >>> d.write(file_name="my_filename.txt", content="Some content")

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -52,6 +52,8 @@ class DirectoryObject:
 
     def __getstate__(self):
         self._protected = True
+        if not hasattr(self.path, "__getstate__"):
+            return self.path.__dict__
         return self.path.__getstate__()
 
     def __del__(self):

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -40,7 +40,9 @@ def categorize_folder_items(folder_path):
 
 
 class DirectoryObject:
-    def __init__(self, directory: str | Path | DirectoryObject, protected: bool = False):
+    def __init__(
+        self, directory: str | Path | DirectoryObject, protected: bool = False
+    ):
         if isinstance(directory, str):
             self.path = Path(directory)
         elif isinstance(directory, Path):

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -52,7 +52,7 @@ class DirectoryObject:
 
     def __getstate__(self):
         self._protected = True
-        return super().__getstate__()
+        return self.path.__getstate__()
 
     def __del__(self):
         if not self._protected:

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -40,7 +40,7 @@ def categorize_folder_items(folder_path):
 
 
 class DirectoryObject:
-    def __init__(self, directory: str | Path | DirectoryObject):
+    def __init__(self, directory: str | Path | DirectoryObject, protected: bool = False):
         if isinstance(directory, str):
             self.path = Path(directory)
         elif isinstance(directory, Path):
@@ -48,7 +48,7 @@ class DirectoryObject:
         elif isinstance(directory, DirectoryObject):
             self.path = directory.path
         self.create()
-        self._protected = False
+        self._protected = protected
 
     def __getstate__(self):
         self._protected = True

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -81,6 +81,11 @@ class DirectoryObject:
         elif isinstance(directory, DirectoryObject):
             self.path = directory.path
         self.create()
+        self._protected = False
+
+    def __getstate__(self):
+        self._protected = True
+        return super().__getstate__()
 
     def create(self):
         self.path.mkdir(parents=True, exist_ok=True)

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -52,10 +52,7 @@ class DirectoryObject:
 
     def __getstate__(self):
         self._protected = True
-        try:
-            return self.path.__getstate__()
-        except AttributeError:
-            return self.path
+        return self.path.__getstate__()
 
     def __del__(self):
         if not self._protected:

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -16,6 +16,8 @@ def delete_files_and_directories_recursively(path):
 
 
 def categorize_folder_items(folder_path):
+    if not folder_path.is_dir():
+        return {}
     types = [
         "dir",
         "file",
@@ -47,10 +49,15 @@ class DirectoryObject:
         elif isinstance(directory, DirectoryObject):
             self.path = directory.path
         self.create()
+        self._protected = False
 
     def __getstate__(self):
         self._protected = True
         return super().__getstate__()
+
+    def __del__(self):
+        if not self._protected:
+            self.delete(only_if_empty=False)
 
     def create(self):
         self.path.mkdir(parents=True, exist_ok=True)

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -52,9 +52,10 @@ class DirectoryObject:
 
     def __getstate__(self):
         self._protected = True
-        if not hasattr(self.path, "__getstate__"):
-            return self.path.__dict__
-        return self.path.__getstate__()
+        try:
+            return self.path.__getstate__()
+        except AttributeError:
+            return self.path
 
     def __del__(self):
         if not self._protected:

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -38,40 +38,6 @@ def categorize_folder_items(folder_path):
     return results
 
 
-def _resolve_directory_and_path(
-    file_name: str,
-    directory: DirectoryObject | str | None = None,
-    default_directory: str = ".",
-):
-    """
-    Internal routine to separate the file name and the directory in case
-    file name is given in absolute path etc.
-    """
-    path = Path(file_name)
-    file_name = path.name
-    if path.is_absolute():
-        if directory is not None:
-            raise ValueError(
-                "You cannot set `directory` when `file_name` is an absolute path"
-            )
-        # If absolute path, take that of new_file_name regardless of the
-        # name of directory
-        directory = str(path.parent)
-    else:
-        if directory is None:
-            # If directory is not given, take default directory
-            directory = default_directory
-        else:
-            # If the directory is given, use it as the main path and append
-            # additional path if given in new_file_name
-            if isinstance(directory, DirectoryObject):
-                directory = directory.path
-        directory = directory / path.parent
-    if not isinstance(directory, DirectoryObject):
-        directory = DirectoryObject(directory)
-    return file_name, directory
-
-
 class DirectoryObject:
     def __init__(self, directory: str | Path | DirectoryObject):
         if isinstance(directory, str):
@@ -81,7 +47,6 @@ class DirectoryObject:
         elif isinstance(directory, DirectoryObject):
             self.path = directory.path
         self.create()
-        self._protected = False
 
     def __getstate__(self):
         self._protected = True
@@ -116,9 +81,6 @@ class DirectoryObject:
     def create_subdirectory(self, path):
         return DirectoryObject(self.path / path)
 
-    def create_file(self, file_name):
-        return FileObject(file_name, self)
-
     def is_empty(self) -> bool:
         return len(self) == 0
 
@@ -127,96 +89,3 @@ class DirectoryObject:
             path = self.get_path(file)
             if path.is_file():
                 path.unlink()
-
-
-class NoDestinationError(ValueError):
-    """A custom error for when neither a new file name nor new location are provided"""
-
-
-class FileObject:
-    def __init__(self, file_name: str, directory: DirectoryObject = None):
-        self._file_name, self.directory = _resolve_directory_and_path(
-            file_name=file_name, directory=directory, default_directory="."
-        )
-
-    @property
-    def file_name(self):
-        return self._file_name
-
-    @property
-    def path(self):
-        return self.directory.path / Path(self._file_name)
-
-    def write(self, content, mode="x"):
-        self.directory.write(file_name=self.file_name, content=content, mode=mode)
-
-    def read(self, mode="r"):
-        with open(self.path, mode=mode) as f:
-            return f.read()
-
-    def is_file(self):
-        return self.directory.file_exists(self.file_name)
-
-    def delete(self):
-        self.path.unlink()
-
-    def __str__(self):
-        return str(self.path.absolute())
-
-    def _resolve_directory_and_path(
-        self,
-        file_name: str,
-        directory: DirectoryObject | str | None = None,
-        default_directory: str = ".",
-    ):
-        """
-        Internal routine to separate the file name and the directory in case
-        file name is given in absolute path etc.
-        """
-        path = Path(file_name)
-        file_name = path.name
-        if path.is_absolute():
-            # If absolute path, take that of new_file_name regardless of the
-            # name of directory
-            directory = str(path.parent)
-        else:
-            if directory is None:
-                # If directory is not given, take default directory
-                directory = default_directory
-            else:
-                # If the directory is given, use it as the main path and append
-                # additional path if given in new_file_name
-                if isinstance(directory, DirectoryObject):
-                    directory = directory.path
-            directory = directory / path.parent
-        if not isinstance(directory, DirectoryObject):
-            directory = DirectoryObject(directory)
-        return file_name, directory
-
-    def copy(
-        self,
-        new_file_name: str | None = None,
-        directory: DirectoryObject | str | None = None,
-    ):
-        """
-        Copy an existing file to a new location.
-        Args:
-            new_file_name (str): New file name. You can also set
-                an absolute path (in which case `directory` will be ignored)
-            directory (DirectoryObject): Directory. If None, the same
-                directory is used
-        Returns:
-            (FileObject): file object of the new file
-        """
-        if new_file_name is None:
-            if directory is None:
-                raise NoDestinationError(
-                    "Either new file name or directory must be specified"
-                )
-            new_file_name = self.file_name
-        file_name, directory = self._resolve_directory_and_path(
-            new_file_name, directory, default_directory=self.directory.path
-        )
-        new_file = FileObject(file_name, directory.path)
-        shutil.copy(str(self.path), str(new_file.path))
-        return new_file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ extend-exclude = '''
 [tool.mypy]
 exclude = [
     "^docs/conf\\.py$",
-    "^pyiron_snippets/files\\.py$",
     "^tests/",
 ]
 ignore_missing_imports = true

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -1,4 +1,3 @@
-import platform
 import unittest
 from pathlib import Path
 
@@ -31,14 +30,14 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(len(self.directory), 1)
 
     def test_del(self):
-        directory = DirectoryObject("something")
+        self.directory = DirectoryObject("something")
         self.assertTrue(Path("something").exists())
-        directory = None
+        self.directory = None
         self.assertFalse(Path("something").exists())
-        directory = DirectoryObject("something")
+        self.directory = DirectoryObject("something")
         self.assertTrue(Path("something").exists())
-        state = directory.__getstate__()
-        directory = None
+        _ = self.directory.__getstate__()
+        self.directory = None
         self.assertTrue(Path("something").exists())
 
     def test_create_subdirectory(self):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 from pathlib import Path
 
@@ -36,7 +37,7 @@ class TestFiles(unittest.TestCase):
         self.assertFalse(Path("something").exists())
         self.directory = DirectoryObject("something")
         self.assertTrue(Path("something").exists())
-        _ = self.directory.__getstate__()
+        _ = pickle.dumps(self.directory)
         self.directory = DirectoryObject("something_else")
         self.assertTrue(Path("something").exists())
         self.directory = DirectoryObject("something")

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -31,7 +31,7 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(len(self.directory), 1)
 
     def test_create_subdirectory(self):
-        self.directory.create_subdirectory("another_test")
+        directory = self.directory.create_subdirectory("another_test")
         self.assertTrue(Path("test/another_test").exists())
 
     def test_is_empty(self):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -43,7 +43,7 @@ class TestFiles(unittest.TestCase):
         self.directory = DirectoryObject("something")
 
     def test_create_subdirectory(self):
-        directory = self.directory.create_subdirectory("another_test")
+        _ = self.directory.create_subdirectory("another_test")
         self.assertTrue(Path("test/another_test").exists())
 
     def test_is_empty(self):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -2,7 +2,7 @@ import platform
 import unittest
 from pathlib import Path
 
-from pyiron_snippets.files import DirectoryObject, FileObject
+from pyiron_snippets.files import DirectoryObject
 
 
 class TestFiles(unittest.TestCase):
@@ -17,23 +17,6 @@ class TestFiles(unittest.TestCase):
         self.assertEqual(directory.path, self.directory.path)
         directory = DirectoryObject(self.directory)
         self.assertEqual(directory.path, self.directory.path)
-
-    def test_file_instantiation(self):
-        self.assertEqual(
-            FileObject("test.txt", self.directory).path,
-            FileObject("test.txt", "test").path,
-            msg="DirectoryObject and str must give the same object",
-        )
-        self.assertEqual(
-            FileObject("test/test.txt").path,
-            FileObject("test.txt", "test").path,
-            msg="File path not same as directory path",
-        )
-
-        if platform.system() == "Windows":
-            self.assertRaises(ValueError, FileObject, "C:\\test.txt", "test")
-        else:
-            self.assertRaises(ValueError, FileObject, "/test.txt", "test")
 
     def test_directory_exists(self):
         self.assertTrue(Path("test").exists() and Path("test").is_dir())
@@ -50,23 +33,6 @@ class TestFiles(unittest.TestCase):
     def test_create_subdirectory(self):
         self.directory.create_subdirectory("another_test")
         self.assertTrue(Path("test/another_test").exists())
-
-    def test_path(self):
-        f = FileObject("test.txt", self.directory)
-        self.assertEqual(str(f.path).replace("\\", "/"), "test/test.txt")
-
-    def test_read_and_write(self):
-        f = FileObject("test.txt", self.directory)
-        f.write("something")
-        self.assertEqual(f.read(), "something")
-
-    def test_is_file(self):
-        f = FileObject("test.txt", self.directory)
-        self.assertFalse(f.is_file())
-        f.write("something")
-        self.assertTrue(f.is_file())
-        f.delete()
-        self.assertFalse(f.is_file())
 
     def test_is_empty(self):
         self.assertTrue(self.directory.is_empty())
@@ -113,34 +79,6 @@ class TestFiles(unittest.TestCase):
             len(self.directory),
             msg="Should be able to remove just one file",
         )
-
-    def test_copy(self):
-        f = FileObject("test_copy.txt", self.directory)
-        f.write("sam wrote this wondrful thing")
-        new_file_1 = f.copy("another_test")
-        self.assertEqual(new_file_1.read(), "sam wrote this wondrful thing")
-        new_file_2 = f.copy("another_test", ".")
-        with open("another_test") as file:
-            txt = file.read()
-        self.assertEqual(txt, "sam wrote this wondrful thing")
-        new_file_2.delete()  # needed because current directory
-        new_file_3 = f.copy(str(f.path.parent / "another_test"), ".")
-        self.assertEqual(new_file_1.path.absolute(), new_file_3.path.absolute())
-        new_file_4 = f.copy(directory=".")
-        with open("test_copy.txt") as file:
-            txt = file.read()
-        self.assertEqual(txt, "sam wrote this wondrful thing")
-        new_file_4.delete()  # needed because current directory
-        with self.assertRaises(ValueError):
-            f.copy()
-
-    def test_str(self):
-        f = FileObject("test_copy.txt", self.directory)
-        if platform.system() == "Windows":
-            txt = f"my file: {self.directory.path.absolute()}\\test_copy.txt"
-        else:
-            txt = f"my file: {self.directory.path.absolute()}/test_copy.txt"
-        self.assertEqual(f"my file: {f}", txt)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -39,6 +39,7 @@ class TestFiles(unittest.TestCase):
         _ = self.directory.__getstate__()
         self.directory = DirectoryObject("something_else")
         self.assertTrue(Path("something").exists())
+        self.directory = DirectoryObject("something")
 
     def test_create_subdirectory(self):
         directory = self.directory.create_subdirectory("another_test")

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -30,6 +30,17 @@ class TestFiles(unittest.TestCase):
         )
         self.assertEqual(len(self.directory), 1)
 
+    def test_del(self):
+        directory = DirectoryObject("something")
+        self.assertTrue(Path("something").exists())
+        directory = None
+        self.assertFalse(Path("something").exists())
+        directory = DirectoryObject("something")
+        self.assertTrue(Path("something").exists())
+        state = directory.__getstate__()
+        directory = None
+        self.assertTrue(Path("something").exists())
+
     def test_create_subdirectory(self):
         directory = self.directory.create_subdirectory("another_test")
         self.assertTrue(Path("test/another_test").exists())

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -37,7 +37,7 @@ class TestFiles(unittest.TestCase):
         self.directory = DirectoryObject("something")
         self.assertTrue(Path("something").exists())
         _ = self.directory.__getstate__()
-        self.directory = None
+        self.directory = DirectoryObject("something_else")
         self.assertTrue(Path("something").exists())
 
     def test_create_subdirectory(self):


### PR DESCRIPTION
Following [this discussion](https://github.com/pyiron/pyiron_workflow/issues/735) I'm now reorganizing `DirectoryObject`.

Main changes:

- I removed `FileObject`, mainly because the distinction didn't much make sense for `pathlib.Path`
- Directory gets now erased once the object gets deleted, **except** if `__getstate__` is called beforehand

Note: I'm assuming no one is currently using `DirectoryObject` or `FileObject`. If that's not true, please let me know.