### PR TITLE
Protect folder if it exists before it was declared

### DIFF
--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -80,7 +80,7 @@ class DirectoryObject:
         ) or generate_unique_directory:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
-            protected = True if path.is_absolute() else False
+            protected = True if path.exists() else False
         self._protected = protected
         self.path: Path = path
         self.create()

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -67,7 +67,7 @@ class DirectoryObject:
                 the directory is "." and this parameter is None.
             protected (bool | None): If True, prevents deletion of the
                 directory object on garbage collection. If None, it defaults to
-                False if the directory does not exist.
+                True if the directory already exists.
         """
         if isinstance(directory, str):
             path = Path(directory)

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -80,10 +80,7 @@ class DirectoryObject:
         ) or generate_unique_directory:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
-            if path.exists():
-                protected = True
-            else:
-                protected = False
+            protected = True if path.is_absolute() else False
         self._protected = protected
         self.path: Path = path
         self.create()

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -80,7 +80,7 @@ class DirectoryObject:
         ) or generate_unique_directory:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
-            protected = True if path.exists() else False
+            protected = path.exists()
         self._protected = protected
         self.path: Path = path
         self.create()

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -54,7 +54,7 @@ class DirectoryObject:
         self,
         directory: str | Path | DirectoryObject = ".",
         generate_unique_directory: bool | None = None,
-        protected: bool = False,
+        protected: bool | None = None,
     ):
         """
         Initialize a DirectoryObject.
@@ -65,8 +65,9 @@ class DirectoryObject:
             generate_unique_directory (bool | None): If True, generates a unique
                 directory name, otherwise it still generates a unique name if
                 the directory is "." and this parameter is None.
-            protected (bool): If True, prevents deletion of the directory object
-                on garbage collection.
+            protected (bool | None): If True, prevents deletion of the
+                directory object on garbage collection. If None, it defaults to
+                False if the directory does not exist.
         """
         if isinstance(directory, str):
             path = Path(directory)
@@ -78,9 +79,14 @@ class DirectoryObject:
             directory == "." and generate_unique_directory is None
         ) or generate_unique_directory:
             path = path / f"data_{uuid.uuid4().hex}"
+        if protected is None:
+            if path.exists():
+                protected = True
+            else:
+                protected = False
+        self._protected = protected
         self.path: Path = path
         self.create()
-        self._protected = protected
 
     def __getstate__(self):
         self._protected = True

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -22,6 +22,16 @@ class TestFiles(unittest.TestCase):
         self.assertTrue(str(directory.path).startswith("data"))
         self.assertEqual(len(str(directory.path)), 37)
 
+    def test_protected(self):
+        directory = DirectoryObject("protected", protected=True)
+        self.assertTrue(directory._protected)
+        directory = DirectoryObject("protected")
+        self.assertTrue(directory._protected)
+        directory.delete()
+        directory = DirectoryObject("protected")
+        self.assertFalse(directory._protected)
+        directory.delete()
+
     def test_directory_exists(self):
         self.assertTrue(Path("test").exists() and Path("test").is_dir())
 


### PR DESCRIPTION
Closes #56 

Now `protected` is `None` by default, which means `True` if the folder already exists, and `False` otherwise.