### PR TITLE
ImportAlarm: Expose _fail_on_warning and rename

### DIFF
--- a/pyiron_snippets/import_alarm.py
+++ b/pyiron_snippets/import_alarm.py
@@ -5,8 +5,6 @@ Graceful failure for missing optional dependencies.
 import functools
 import warnings
 
-from pyiron_snippets.deprecate import deprecate
-
 
 class ImportAlarmError(ImportError):
     """To be raised instead of a warning when a package is missing."""
@@ -47,12 +45,10 @@ class ImportAlarm:
     >>> import_alarm.warn_if_failed()
     """
 
-    @deprecate(_fail_on_warning="use fail_on_warning instead")
     def __init__(
         self,
         message=None,
         raise_exception: bool = False,
-        _fail_on_warning: bool = False,
     ):
         """
         Initialize message value.
@@ -68,7 +64,7 @@ class ImportAlarm:
         self.message = message
         # Catching warnings in tests can be janky, so instead open a flag for failing
         # instead.
-        self.raise_exception = raise_exception or _fail_on_warning
+        self.raise_exception = raise_exception
 
     def __call__(self, func):
         return self.wrapper(func)

--- a/tests/unit/test_import_alarm.py
+++ b/tests/unit/test_import_alarm.py
@@ -6,13 +6,13 @@ from pyiron_snippets.import_alarm import ImportAlarm, ImportAlarmError
 class TestImportAlarm(unittest.TestCase):
 
     def test_instance(self):
-        no_alarm = ImportAlarm(_fail_on_warning=True)
+        no_alarm = ImportAlarm(raise_exception=True)
 
         @no_alarm
         def add_one(x):
             return x + 1
 
-        yes_alarm = ImportAlarm("Here is a message", _fail_on_warning=True)
+        yes_alarm = ImportAlarm("Here is a message", raise_exception=True)
 
         @yes_alarm
         def subtract_one(x):
@@ -37,11 +37,11 @@ class TestImportAlarm(unittest.TestCase):
             subtract_one(0)
 
     def test_context(self):
-        with ImportAlarm("Working import", _fail_on_warning=True) as alarm_working:
+        with ImportAlarm("Working import", raise_exception=True) as alarm_working:
             # Suppose all the imports here pass fine
             pass
 
-        with ImportAlarm("Broken import", _fail_on_warning=True) as alarm_broken:
+        with ImportAlarm("Broken import", raise_exception=True) as alarm_broken:
             raise ImportError("Suppose a package imported here is not available")
 
         @alarm_working


### PR DESCRIPTION
Sometimes there is nothing useful to be done on a missing (optional) dependency, but the current behavior forces users to handle this case in the decorated function itself.  With this change, this case can simply raise an exception in case e.g. a function is called that is only part of a package API if the depedency is met.