### PR TITLE
Extend VersionInfo 

### DIFF
--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -85,6 +85,7 @@ class VersionInfo:
         forbid_locals: bool = False,
         forbid_lambda: bool = False,
         require_version: bool = False,
+        strict: bool = False,
     ) -> VersionInfo:
         """
         Construct a :class:`VersionInfo` by introspecting *obj*.
@@ -106,6 +107,7 @@ class VersionInfo:
                 contains ``<lambda>``.
             require_version: If ``True``, raise :exc:`ValueError` when no
                 version can be determined for the module.
+            strict: A shortcut to turn on all the other forbid and require flags.
 
         Returns:
             A new :class:`VersionInfo` instance.
@@ -123,6 +125,7 @@ class VersionInfo:
             forbid_locals=forbid_locals,
             forbid_lambda=forbid_lambda,
             require_version=require_version,
+            strict=strict,
         )
         return info
 
@@ -132,17 +135,18 @@ class VersionInfo:
         forbid_locals: bool = False,
         forbid_lambda: bool = False,
         require_version: bool = False,
+        strict: bool = False,
     ) -> Self:
-        if forbid_main and self.in_main:
+        if (strict or forbid_main) and self.in_main:
             raise ValueError(f"Found forbidden module '__main__' in module for {self}")
 
-        if forbid_locals and self.is_local:
+        if (strict or forbid_locals) and self.is_local:
             raise ValueError(f"Found forbidden <locals> in qualname for {self}")
 
-        if forbid_lambda and self.is_lambda:
+        if (strict or forbid_lambda) and self.is_lambda:
             raise ValueError(f"Found forbidden <lambda> in qualname for {self}")
 
-        if require_version and not self.has_version:
+        if (strict or require_version) and not self.has_version:
             raise ValueError(f"Could not find a version for {self}")
 
         return self

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -60,6 +60,18 @@ class VersionInfo:
         else:
             return self.fully_qualified_name
 
+    @property
+    def is_local(self) -> bool:
+        return self.qualname is not None and "<locals>" in self.qualname
+
+    @property
+    def in_main(self) -> bool:
+        return "__main__" in self.module
+
+    @property
+    def has_version(self) -> bool:
+        return self.version is not None
+
     @classmethod
     def of(
         cls,
@@ -112,13 +124,13 @@ class VersionInfo:
         forbid_locals: bool = False,
         require_version: bool = False,
     ) -> Self:
-        if forbid_main and "__main__" in self.module:
+        if forbid_main and self.in_main:
             raise ValueError(f"Found forbidden module '__main__' in module for {self}")
 
-        if forbid_locals and self.qualname is not None and "<locals>" in self.qualname:
+        if forbid_locals and self.is_local:
             raise ValueError(f"Found forbidden <locals> in qualname for {self}")
 
-        if require_version and self.version is None:
+        if require_version and not self.has_version:
             raise ValueError(f"Could not find a version for {self}")
 
         return self

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -65,6 +65,10 @@ class VersionInfo:
         return self.qualname is not None and "<locals>" in self.qualname
 
     @property
+    def is_lambda(self) -> bool:
+        return self.qualname is not None and "<lambda>" in self.qualname
+
+    @property
     def in_main(self) -> bool:
         return "__main__" in self.module
 
@@ -79,6 +83,7 @@ class VersionInfo:
         version_scraping: VersionScrapingMap | None = None,
         forbid_main: bool = False,
         forbid_locals: bool = False,
+        forbid_lambda: bool = False,
         require_version: bool = False,
     ) -> VersionInfo:
         """
@@ -97,6 +102,8 @@ class VersionInfo:
             forbid_locals: If ``True``, raise :exc:`ValueError` when the
                 qualname contains ``<locals>`` (i.e. the type was defined
                 inside a function).
+            forbid_lambda: If ``True``, raise :exc:`ValueError` when the qualname
+                contains ``<lambda>``.
             require_version: If ``True``, raise :exc:`ValueError` when no
                 version can be determined for the module.
 
@@ -114,6 +121,7 @@ class VersionInfo:
         info.validate_constraints(
             forbid_main=forbid_main,
             forbid_locals=forbid_locals,
+            forbid_lambda=forbid_lambda,
             require_version=require_version,
         )
         return info
@@ -122,6 +130,7 @@ class VersionInfo:
         self,
         forbid_main: bool = False,
         forbid_locals: bool = False,
+        forbid_lambda: bool = False,
         require_version: bool = False,
     ) -> Self:
         if forbid_main and self.in_main:
@@ -129,6 +138,9 @@ class VersionInfo:
 
         if forbid_locals and self.is_local:
             raise ValueError(f"Found forbidden <locals> in qualname for {self}")
+
+        if forbid_lambda and self.is_lambda:
+            raise ValueError(f"Found forbidden <lambda> in qualname for {self}")
 
         if require_version and not self.has_version:
             raise ValueError(f"Could not find a version for {self}")

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -52,7 +52,7 @@ class VersionInfo:
         return f"{self.module}.{self.qualname}"
 
     @property
-    def usable_name(self) -> str:
+    def findable_at(self) -> str:
         if self.qualname is None:
             return self.module
         elif self.module == "builtins":

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -51,6 +51,15 @@ class VersionInfo:
             return self.module
         return f"{self.module}.{self.qualname}"
 
+    @property
+    def usable_name(self) -> str:
+        if self.qualname is None:
+            return self.module
+        elif self.module == "builtins":
+            return self.qualname
+        else:
+            return self.fully_qualified_name
+
     @classmethod
     def of(
         cls,

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -376,6 +376,11 @@ class TestVersionInfoOf(unittest.TestCase):
     def test_function(self) -> None:
         info = VersionInfo.of(_dummy_function)
         self.assertEqual(info.qualname, "_dummy_function")
+        
+    def test_lambda_function(self) -> None:
+        _lambda = lambda: 5
+        info = VersionInfo.of(_lambda)
+        self.assertIn("<lambda>", info.qualname)
 
     def test_builtin_instance(self) -> None:
         info = VersionInfo.of(42)
@@ -457,6 +462,26 @@ class TestVersionInfoOf(unittest.TestCase):
         info = VersionInfo.of(os, forbid_locals=True)
         self.assertIsNone(info.qualname)
 
+    # -- forbid_lambda ------------------------------------------------------
+
+    def test_forbid_lambda_raises(self) -> None:
+        _lambda = lambda: 5
+
+        self.assertIn("<lambda>", _lambda.__qualname__)
+        with self.assertRaises(ValueError, msg="<lambda>"):
+            VersionInfo.of(_lambda, forbid_lambda=True)
+
+    def test_forbid_lambda_false_allows_lambda(self) -> None:
+        _lambda = lambda: 5
+
+        info = VersionInfo.of(_lambda, forbid_lambda=False)
+        self.assertIn("<lambda>", info.qualname)
+
+    def test_forbid_lambda_ok_for_module(self) -> None:
+        """forbid_lambda should not crash when qualname is None (modules)."""
+        info = VersionInfo.of(os, forbid_lambda=True)
+        self.assertIsNone(info.qualname)
+
     # -- require_version ----------------------------------------------------
 
     def test_require_version_raises_when_missing(self) -> None:
@@ -524,6 +549,19 @@ class TestValidateConstraints(unittest.TestCase):
     def test_forbid_locals_passes_none_qualname(self) -> None:
         info = VersionInfo(module="os", qualname=None, version=PYTHON_VERSION)
         self.assertIs(info.validate_constraints(forbid_locals=True), info)
+        
+    def test_forbid_lambda_raises(self) -> None:
+        info = VersionInfo(module="m", qualname="mod.<lambda>", version=None)
+        with self.assertRaises(ValueError, msg="<lambda>"):
+            info.validate_constraints(forbid_lambda=True)
+
+    def test_forbid_lambda_passes_normal_qualname(self) -> None:
+        info = VersionInfo(module="m", qualname="Outer.Inner", version="1.0")
+        self.assertIs(info.validate_constraints(forbid_lambda=True), info)
+
+    def test_forbid_lambda_passes_none_qualname(self) -> None:
+        info = VersionInfo(module="os", qualname=None, version=PYTHON_VERSION)
+        self.assertIs(info.validate_constraints(forbid_lambda=True), info)
 
     def test_require_version_raises_when_none(self) -> None:
         info = VersionInfo(module="m", qualname="X", version=None)

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -378,7 +378,7 @@ class TestVersionInfoOf(unittest.TestCase):
         self.assertEqual(info.qualname, "_dummy_function")
 
     def test_lambda_function(self) -> None:
-        _lambda = lambda: 5
+        _lambda = lambda: 5  # noqa: E731
         info = VersionInfo.of(_lambda)
         self.assertIn("<lambda>", info.qualname)
 
@@ -471,7 +471,7 @@ class TestVersionInfoOf(unittest.TestCase):
     # -- forbid_lambda ------------------------------------------------------
 
     def test_forbid_lambda_raises(self) -> None:
-        _lambda = lambda: 5
+        _lambda = lambda: 5  # noqa: E731
 
         self.assertIn("<lambda>", _lambda.__qualname__)
         with self.assertRaises(ValueError, msg="<lambda>"):
@@ -481,7 +481,7 @@ class TestVersionInfoOf(unittest.TestCase):
             VersionInfo.of(_lambda, strict=True)
 
     def test_forbid_lambda_false_allows_lambda(self) -> None:
-        _lambda = lambda: 5
+        _lambda = lambda: 5  # noqa: E731
 
         info = VersionInfo.of(_lambda, forbid_lambda=False)
         self.assertIn("<lambda>", info.qualname)

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -401,6 +401,7 @@ class TestVersionInfoOf(unittest.TestCase):
     def test_module(self) -> None:
         info = VersionInfo.of(os)
         self.assertEqual(info.module, "os")
+        self.assertEqual(info.usable_name, info.module)
         self.assertIsNone(info.qualname)
         self.assertEqual(info.version, PYTHON_VERSION)
 

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -367,7 +367,7 @@ class TestVersionInfoOf(unittest.TestCase):
         info = VersionInfo.of(_Dummy)
         self.assertEqual(info.module, _Dummy.__module__)
         self.assertEqual(info.qualname, "_Dummy")
-        self.assertEqual(info.usable_name, info.fully_qualified_name)
+        self.assertEqual(info.findable_at, info.fully_qualified_name)
 
     def test_instance(self) -> None:
         info = VersionInfo.of(_Dummy())
@@ -386,14 +386,14 @@ class TestVersionInfoOf(unittest.TestCase):
         info = VersionInfo.of(42)
         self.assertEqual(info.module, "builtins")
         self.assertEqual(info.qualname, "int")
-        self.assertEqual(info.usable_name, info.qualname)
+        self.assertEqual(info.findable_at, info.qualname)
         self.assertIsNotNone(info.version)
 
     def test_builtin_type(self) -> None:
         info = VersionInfo.of(int)
         self.assertEqual(info.module, "builtins")
         self.assertEqual(info.qualname, "int")
-        self.assertEqual(info.usable_name, info.qualname)
+        self.assertEqual(info.findable_at, info.qualname)
         self.assertIsNotNone(info.version)
 
     # -- modules ------------------------------------------------------------
@@ -401,7 +401,7 @@ class TestVersionInfoOf(unittest.TestCase):
     def test_module(self) -> None:
         info = VersionInfo.of(os)
         self.assertEqual(info.module, "os")
-        self.assertEqual(info.usable_name, info.module)
+        self.assertEqual(info.findable_at, info.module)
         self.assertIsNone(info.qualname)
         self.assertEqual(info.version, PYTHON_VERSION)
 

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -367,6 +367,7 @@ class TestVersionInfoOf(unittest.TestCase):
         info = VersionInfo.of(_Dummy)
         self.assertEqual(info.module, _Dummy.__module__)
         self.assertEqual(info.qualname, "_Dummy")
+        self.assertEqual(info.usable_name, info.fully_qualified_name)
 
     def test_instance(self) -> None:
         info = VersionInfo.of(_Dummy())
@@ -380,12 +381,14 @@ class TestVersionInfoOf(unittest.TestCase):
         info = VersionInfo.of(42)
         self.assertEqual(info.module, "builtins")
         self.assertEqual(info.qualname, "int")
+        self.assertEqual(info.usable_name, info.qualname)
         self.assertIsNotNone(info.version)
 
     def test_builtin_type(self) -> None:
         info = VersionInfo.of(int)
         self.assertEqual(info.module, "builtins")
         self.assertEqual(info.qualname, "int")
+        self.assertEqual(info.usable_name, info.qualname)
         self.assertIsNotNone(info.version)
 
     # -- modules ------------------------------------------------------------

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -376,7 +376,7 @@ class TestVersionInfoOf(unittest.TestCase):
     def test_function(self) -> None:
         info = VersionInfo.of(_dummy_function)
         self.assertEqual(info.qualname, "_dummy_function")
-        
+
     def test_lambda_function(self) -> None:
         _lambda = lambda: 5
         info = VersionInfo.of(_lambda)
@@ -425,6 +425,9 @@ class TestVersionInfoOf(unittest.TestCase):
         with self.assertRaises(ValueError, msg="__main__"):
             VersionInfo.of(obj, forbid_main=True)
 
+        with self.assertRaises(ValueError, msg="__main__"):
+            VersionInfo.of(obj, strict=True)
+
     def test_forbid_main_false_allows_main(self) -> None:
         obj = mock.MagicMock(spec=type)
         obj.__module__ = "__main__"
@@ -445,6 +448,9 @@ class TestVersionInfoOf(unittest.TestCase):
         self.assertIn("<locals>", local_cls.__qualname__)
         with self.assertRaises(ValueError, msg="<locals>"):
             VersionInfo.of(local_cls, forbid_locals=True)
+
+        with self.assertRaises(ValueError, msg="<locals>"):
+            VersionInfo.of(local_cls, strict=True)
 
     def test_forbid_locals_false_allows_locals(self) -> None:
         def _make_local() -> type:
@@ -471,6 +477,9 @@ class TestVersionInfoOf(unittest.TestCase):
         with self.assertRaises(ValueError, msg="<lambda>"):
             VersionInfo.of(_lambda, forbid_lambda=True)
 
+        with self.assertRaises(ValueError, msg="<lambda>"):
+            VersionInfo.of(_lambda, strict=True)
+
     def test_forbid_lambda_false_allows_lambda(self) -> None:
         _lambda = lambda: 5
 
@@ -495,6 +504,12 @@ class TestVersionInfoOf(unittest.TestCase):
             self.assertRaises(ValueError, msg="could not be found"),
         ):
             VersionInfo.of(fake_obj, require_version=True)
+
+        with (
+            mock.patch.dict("sys.modules", {"no_version_pkg": fake_mod}),
+            self.assertRaises(ValueError, msg="could not be found"),
+        ):
+            VersionInfo.of(fake_obj, strict=True)
 
     def test_require_version_ok_when_present(self) -> None:
         info = VersionInfo.of(42, require_version=True)
@@ -532,6 +547,8 @@ class TestValidateConstraints(unittest.TestCase):
         info = VersionInfo(module="__main__", qualname="Foo", version=None)
         with self.assertRaises(ValueError, msg="__main__"):
             info.validate_constraints(forbid_main=True)
+        with self.assertRaises(ValueError, msg="__main__"):
+            info.validate_constraints(strict=True)
 
     def test_forbid_main_passes_normal_module(self) -> None:
         info = VersionInfo(module="some.pkg", qualname="Foo", version=None)
@@ -541,6 +558,8 @@ class TestValidateConstraints(unittest.TestCase):
         info = VersionInfo(module="m", qualname="f.<locals>.Cls", version=None)
         with self.assertRaises(ValueError, msg="<locals>"):
             info.validate_constraints(forbid_locals=True)
+        with self.assertRaises(ValueError, msg="<locals>"):
+            info.validate_constraints(strict=True)
 
     def test_forbid_locals_passes_normal_qualname(self) -> None:
         info = VersionInfo(module="m", qualname="Outer.Inner", version="1.0")
@@ -549,11 +568,13 @@ class TestValidateConstraints(unittest.TestCase):
     def test_forbid_locals_passes_none_qualname(self) -> None:
         info = VersionInfo(module="os", qualname=None, version=PYTHON_VERSION)
         self.assertIs(info.validate_constraints(forbid_locals=True), info)
-        
+
     def test_forbid_lambda_raises(self) -> None:
         info = VersionInfo(module="m", qualname="mod.<lambda>", version=None)
         with self.assertRaises(ValueError, msg="<lambda>"):
             info.validate_constraints(forbid_lambda=True)
+        with self.assertRaises(ValueError, msg="<lambda>"):
+            info.validate_constraints(strict=True)
 
     def test_forbid_lambda_passes_normal_qualname(self) -> None:
         info = VersionInfo(module="m", qualname="Outer.Inner", version="1.0")
@@ -567,6 +588,8 @@ class TestValidateConstraints(unittest.TestCase):
         info = VersionInfo(module="m", qualname="X", version=None)
         with self.assertRaises(ValueError):
             info.validate_constraints(require_version=True)
+        with self.assertRaises(ValueError):
+            info.validate_constraints(strict=True)
 
     def test_require_version_passes_when_present(self) -> None:
         info = VersionInfo(module="m", qualname="X", version="1.0.0")
@@ -583,9 +606,7 @@ class TestValidateConstraints(unittest.TestCase):
         """An info that violates multiple constraints raises on the first check."""
         info = VersionInfo(module="__main__", qualname="f.<locals>.C", version=None)
         with self.assertRaises(ValueError, msg="__main__"):
-            info.validate_constraints(
-                forbid_main=True, forbid_locals=True, require_version=True
-            )
+            info.validate_constraints(strict=True)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
With some QoL properties and extra things you can forbid. Fully backwards compatible, just extends attributes and kwargs.