### PR TITLE
Retrieve version

### DIFF
--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -153,6 +153,56 @@ class VersionInfo:
 
         return self
 
+    def retrieve(
+        self, version_scraping: VersionScrapingMap | None = None, strict: bool = False
+    ) -> object:
+        """
+        Import the object stored at the module and qualname.
+
+
+        Args:
+            version_scraping: Optional mapping from top-level package names to
+                callables that return a version string (or ``None``). Used to
+                handle packages that don't expose ``__version__``.
+            strict: If ``True``, raises a value error if the version of the imported
+                module does not match the versions tored here.
+
+        Returns:
+            The imported object.
+        """
+        try:
+            obj = importlib.import_module(self.module)
+            if strict:
+                actual_version = get_version(
+                    self.module, version_scraping=version_scraping
+                )
+                if actual_version != self.version:
+                    raise ValueError(
+                        f"When retrieving {self.fully_qualified_name}, {self.module} "
+                        f"had the version {actual_version} while {self.version} was "
+                        f"expected."
+                    )
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                f"Could not import the module {self.module}. The most likely causes "
+                f"of this problem are a typo, or that the module is not yet in your "
+                f"system's PYTHONPATH. The latter can be checked from inside python "
+                f"with `import sys; print(sys.path)`."
+            ) from e
+
+        for k in (self.qualname or "").split("."):
+            if k == "":
+                break
+            try:
+                obj = getattr(obj, k)
+            except AttributeError:
+                # Try importing as a submodule
+                # This can be necessary of an __init__.py is empty and nothing else has
+                # referenced the module yet
+                current_path = f"{obj.__name__}.{k}"
+                obj = importlib.import_module(current_path)
+        return obj
+
 
 @dataclasses.dataclass(frozen=True)
 class VersionInfoFactory:

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -178,9 +178,9 @@ class VersionInfo:
                 )
                 if actual_version != self.version:
                     raise ValueError(
-                        f"When retrieving {self.fully_qualified_name}, {self.module} "
-                        f"had the version {actual_version} while {self.version} was "
-                        f"expected."
+                        f"When retrieving {self.fully_qualified_name!r}, "
+                        f"{self.module!r} had the version {actual_version!r} while "
+                        f"{self.version!r} was expected."
                     )
         except ModuleNotFoundError as e:
             raise ModuleNotFoundError(

--- a/pyiron_snippets/versions.py
+++ b/pyiron_snippets/versions.py
@@ -44,8 +44,8 @@ class VersionInfo:
     """
 
     module: str
-    qualname: str | None
-    version: str | None
+    qualname: str | None = None
+    version: str | None = None
 
     @property
     def fully_qualified_name(self) -> str:

--- a/tests/unit/test_versions.py
+++ b/tests/unit/test_versions.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import collections
 import dataclasses
+import importlib
 import io
 import os
+import pathlib
 import re
+import shutil
 import sys
+import textwrap
 import unittest
 from types import BuiltinMethodType, ModuleType
 from unittest import mock
 
+from pyiron_snippets import singleton
 from pyiron_snippets.versions import (
     VersionInfo,
     VersionInfoFactory,
@@ -747,6 +752,209 @@ class TestFullyQualifiedName(unittest.TestCase):
     def test_module_fqn_is_just_module(self) -> None:
         info = VersionInfo.of(os)
         self.assertEqual(info.fully_qualified_name, "os")
+
+
+class TestImportFromString(unittest.TestCase):
+    """Test cases for import_from_string function."""
+
+    def setUp(self):
+        """Add static test files to path for testing."""
+        self.static_path = pathlib.Path(__file__).parent.parent / "static"
+        if str(self.static_path) not in sys.path:
+            sys.path.insert(0, str(self.static_path))
+
+    def tearDown(self):
+        """Clean up sys.path and modules."""
+        if str(self.static_path) in sys.path:
+            sys.path.remove(str(self.static_path))
+        keys_to_remove = [k for k in sys.modules if k.startswith("test_module")]
+        for key in keys_to_remove:
+            del sys.modules[key]
+
+    def test_import_builtin_module(self):
+        """Test importing a standard library module."""
+        result = VersionInfo("os").retrieve()
+        import os
+
+        self.assertIs(result, os)
+
+    def test_import_builtin_function(self):
+        """Test importing a function from standard library."""
+        result = VersionInfo("os.path", "join").retrieve()
+        from os.path import join
+
+        self.assertIs(result, join)
+
+    def test_import_builtin_class(self):
+        """Test importing a class from standard library."""
+        result = VersionInfo("pathlib", "Path").retrieve()
+        from pathlib import Path
+
+        self.assertIs(result, Path)
+
+    def test_import_nested_attribute(self):
+        """Test importing deeply nested attributes."""
+        result = VersionInfo("unittest", "TestCase.assertEqual").retrieve()
+        self.assertEqual(result, unittest.TestCase.assertEqual)
+
+    def test_import_from_pyiron_snippets(self):
+        """Test importing from the pyiron_snippets package itself."""
+        result = VersionInfo("pyiron_snippets.singleton", "Singleton").retrieve()
+        self.assertIs(result, singleton.Singleton)
+
+    def test_import_nonexistent_module(self):
+        """Test that importing non-existent module raises ModuleNotFoundError."""
+        with self.assertRaises(ModuleNotFoundError) as cm:
+            VersionInfo("nonexistent_module").retrieve()
+        self.assertIn("nonexistent_module", str(cm.exception))
+        self.assertIn("PYTHONPATH", str(cm.exception))
+
+    def test_import_nonexistent_attribute(self):
+        """Test that importing non-existent attribute raises AttributeError."""
+        with self.assertRaises(ModuleNotFoundError) as cm:
+            VersionInfo("os", "nonexistent_attr").retrieve()
+        self.assertIn("nonexistent_attr", str(cm.exception))
+
+    def test_import_empty_string(self):
+        """Test edge case with empty string."""
+        with self.assertRaises(ValueError):
+            VersionInfo("").retrieve()
+
+    def test_import_single_name(self):
+        """Test importing just a module name without any dots."""
+        result = VersionInfo("sys").retrieve()
+        import sys
+
+        self.assertIs(result, sys)
+
+    def test_import_from_uninitialized_submodule(self):
+        """Test importing from a submodule that hasn't been initialized yet."""
+        test_pkg_dir = self.static_path / "test_module_uninit"
+        test_pkg_dir.mkdir(parents=True, exist_ok=True)
+
+        (test_pkg_dir / "__init__.py").write_text("")
+
+        submodule_content = textwrap.dedent("""
+            class UnInitClass:
+                value = 42
+            """).strip()
+        (test_pkg_dir / "submodule.py").write_text(submodule_content)
+
+        try:
+            uninitialized = importlib.import_module("test_module_uninit")
+            self.assertNotIn("submodule", dir(uninitialized))
+            result = VersionInfo(
+                "test_module_uninit.submodule", "UnInitClass"
+            ).retrieve()
+            self.assertEqual(
+                result.value,
+                42,
+                msg="Even with an unitialized submodule, the class value still be importable",
+            )
+        finally:
+            shutil.rmtree(test_pkg_dir)
+
+    def test_import_class_method(self):
+        """Test importing a method from a class."""
+        result = VersionInfo("pathlib", "Path.exists").retrieve()
+        from pathlib import Path
+
+        self.assertEqual(result, Path.exists)
+
+    def test_strict(self):
+        with self.assertRaises(ValueError):
+            VersionInfo("sys", version="not my python version").retrieve(strict=True)
+
+
+class TestRetrieveIntegration(unittest.TestCase):
+    """Integration tests for real-world scenarios."""
+
+    def setUp(self):
+        """Set up test environment."""
+        self.static_path = pathlib.Path(__file__).parent.parent / "static"
+        if str(self.static_path) not in sys.path:
+            sys.path.insert(0, str(self.static_path))
+
+    def tearDown(self):
+        """Clean up test environment."""
+        if str(self.static_path) in sys.path:
+            sys.path.remove(str(self.static_path))
+        keys_to_remove = [k for k in sys.modules if k.startswith("test_package")]
+        for key in keys_to_remove:
+            del sys.modules[key]
+
+    def test_complex_package_structure(self):
+        """Test with a complex package structure."""
+        # Create a test package structure
+        pkg_dir = self.static_path / "test_package_complex"
+        sub_pkg_dir = pkg_dir / "subpackage"
+        sub_pkg_dir.mkdir(parents=True, exist_ok=True)
+
+        (pkg_dir / "__init__.py").write_text(
+            "from .module1 import Class1\n__all__ = ['Class1']"
+        )
+        (sub_pkg_dir / "__init__.py").write_text("")
+
+        (pkg_dir / "module1.py").write_text(textwrap.dedent("""
+                class Class1:
+                    value = 'from_module1'
+                """).strip())
+
+        (sub_pkg_dir / "module2.py").write_text(textwrap.dedent("""
+                class Class2:
+                    value = 'from_module2'
+
+                    class NestedClass:
+                        nested_value = 'nested'
+                """).strip())
+
+        try:
+            result1 = VersionInfo("test_package_complex", "Class1").retrieve()
+            self.assertEqual(result1.value, "from_module1")
+
+            result2 = VersionInfo("test_package_complex.module1", "Class1").retrieve()
+            self.assertEqual(result2.value, "from_module1")
+
+            result3 = VersionInfo(
+                "test_package_complex.subpackage.module2", "Class2"
+            ).retrieve()
+            self.assertEqual(result3.value, "from_module2")
+
+            result4 = VersionInfo(
+                "test_package_complex.subpackage.module2", "Class2.NestedClass"
+            ).retrieve()
+            self.assertEqual(result4.nested_value, "nested")
+
+        finally:
+            shutil.rmtree(pkg_dir)
+
+    def test_circular_import_handling(self):
+        """Test that circular imports are handled gracefully."""
+        pkg_dir = self.static_path / "test_circular"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+
+        (pkg_dir / "__init__.py").write_text("")
+        (pkg_dir / "module_a.py").write_text(textwrap.dedent("""
+                from .module_b import ClassB
+
+                class ClassA:
+                    related = ClassB
+                    value = 'A'
+                """).strip())
+        (pkg_dir / "module_b.py").write_text(textwrap.dedent("""
+                class ClassB:
+                    value = 'B'
+
+                # Circular import:
+                from .module_a import ClassA
+                """).strip())
+
+        try:
+            with self.assertRaises(ImportError, msg="Circular imports never work"):
+                VersionInfo("test_circular.module_a", "ClassA").retrieve()
+
+        finally:
+            shutil.rmtree(pkg_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While I was [playing in `pyiron_database`](https://github.com/pyiron/pyiron_database/pull/45), I liked how `recreate_type` gave the option to fail if the imported type didn't meet an expected value. When I looked at putting this in the `retrieve` module, I discovered I wanted tools from `versions`. I decided it would be more convenient to just wrap the retrieval functionality into `VersionInfo`, which anyhow already has a module and qualname. So now you can import your version info objects:

```python
from pyiron_snippets import versions

cls = versions.VersionInfo("pathlib", "Path").retrieve()
print(cls(".").resolve())
>>> /Users/liamhuber/dev/pyiron/notebooks

```

And demand that they have a particular version:

```python
cls = versions.VersionInfo(
    "pathlib", "Path", version="the loaded version won't have this reference"
).retrieve(strict=True)

>>> ValueError: When retrieving 'pathlib.Path', 'pathlib' had the version '3.12.7' while "the loaded version won't have this reference" was expected.

```


In the long run, I can see this deprecating `retrieve` -- it's other tool `get_importable_string_from_string_reduction` is only used in `bagofholding` AFAIK and could be moved there. But in the meantime, I find this to be a pleasant and convenient power-up for `VersionInfo`.