### PR TITLE
feat: create a unique directory if the user does not specify a path

### DIFF
--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -96,7 +96,7 @@ class DirectoryObject:
             raise TypeError(
                 "directory must be str, pathlib.Path, DirectoryObject, or None"
             )
-        if generate_unique_directory:
+        if generate_unique_directory and directory is not None:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
             protected = path.exists()

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -68,7 +68,7 @@ class DirectoryObject:
 
     def __init__(
         self,
-        directory: str | Path | DirectoryObject = ".",
+        directory: str | Path | DirectoryObject | None = None,
         generate_unique_directory: bool | None = None,
         protected: bool | None = None,
     ):
@@ -76,24 +76,27 @@ class DirectoryObject:
         Initialize a DirectoryObject.
 
         Args:
-            directory (str | Path | DirectoryObject): The directory path or
-                DirectoryObject instance.
+            directory (str | Path | DirectoryObject | None): The directory path or
+                DirectoryObject instance. If None, a unique directory is created.
             generate_unique_directory (bool | None): If True, generates a unique
-                directory name, otherwise it still generates a unique name if
-                the directory is "." and this parameter is None.
+                subdirectory name under ``directory``.
             protected (bool | None): If True, prevents deletion of the
                 directory object on garbage collection. If None, it defaults to
                 True if the directory already exists.
         """
-        if isinstance(directory, str):
+        if directory is None:
+            path = Path(f"data_{uuid.uuid4().hex}")
+        elif isinstance(directory, str):
             path = Path(directory)
         elif isinstance(directory, Path):
             path = directory
         elif isinstance(directory, DirectoryObject):
             path = directory.path
-        if (
-            directory == "." and generate_unique_directory is None
-        ) or generate_unique_directory:
+        else:
+            raise TypeError(
+                "directory must be str, pathlib.Path, DirectoryObject, or None"
+            )
+        if generate_unique_directory:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
             protected = path.exists()

--- a/pyiron_snippets/files.py
+++ b/pyiron_snippets/files.py
@@ -96,7 +96,10 @@ class DirectoryObject:
             raise TypeError(
                 "directory must be str, pathlib.Path, DirectoryObject, or None"
             )
-        if generate_unique_directory and directory is not None:
+        if (
+            generate_unique_directory
+            or (directory == "." and generate_unique_directory is None)
+        ) and directory is not None:
             path = path / f"data_{uuid.uuid4().hex}"
         if protected is None:
             protected = path.exists()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -23,6 +23,19 @@ class TestFiles(unittest.TestCase):
         self.assertTrue(str(directory.path).startswith("data"))
         self.assertEqual(len(str(directory.path)), 37)
 
+    def test_directory_invalid_type_raises(self):
+        with self.assertRaises(TypeError):
+            DirectoryObject(directory=42)
+
+    def test_generate_unique_directory_no_nesting_when_directory_is_none(self):
+        directory = DirectoryObject(directory=None, generate_unique_directory=True)
+        try:
+            # Path should have only one component (no nested UUID subdirectory)
+            self.assertEqual(len(directory.path.parts), 1)
+            self.assertTrue(str(directory.path).startswith("data_"))
+        finally:
+            directory.delete()
+
     def test_protected(self):
         directory = DirectoryObject("protected", protected=True)
         self.assertTrue(directory._protected)


### PR DESCRIPTION
This pull request updates the initialization logic for the `DirectoryObject` class in `files.py` to make directory handling more robust and flexible. The most important changes are:

Directory initialization improvements:
* The `directory` parameter in `DirectoryObject.__init__` now accepts `None` as a value. If `directory` is `None`, a unique directory is automatically created using a UUID. This enhances usability for cases where a user wants an isolated working directory without specifying a path.
* Improved the logic for generating unique subdirectories: the `generate_unique_directory` parameter now always creates a unique subdirectory under the given `directory` when set to `True`, simplifying the previous conditional logic.
* Added explicit error handling: if `directory` is not a `str`, `Path`, `DirectoryObject`, or `None`, a `TypeError` is raised with a clear message.

Documentation updates:
* Updated the docstring for `DirectoryObject.__init__` to reflect the new behavior and clarify the meaning of the parameters.